### PR TITLE
Fix `--no-color` to really remove all colors from Landscape output

### DIFF
--- a/lib/yle_tf-landscape/command.rb
+++ b/lib/yle_tf-landscape/command.rb
@@ -35,9 +35,15 @@ module YleTfPlugins
       end
 
       def landscape_output(env)
-        TerraformLandscape::Output.new(STDOUT).tap do |output|
-          output.color_enabled = false if env[:tf_options][:no_color]
+        output = TerraformLandscape::Output.new(STDOUT)
+
+        # Disable colors in Landscape
+        if env[:tf_options][:no_color]
+          String.disable_colorization = true
+          output.color_enabled = false
         end
+
+        output
       end
     end
   end


### PR DESCRIPTION
The colorization is actually made with `colorize`.